### PR TITLE
Lowered the minimum frequency even further

### DIFF
--- a/dsx-fw/.settings/language.settings.xml
+++ b/dsx-fw/.settings/language.settings.xml
@@ -6,7 +6,7 @@
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1260728338053048147" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="141083505835979496" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -18,7 +18,7 @@
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1260728338053048147" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="141083505835979496" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/dsx-fw/DSX_Library/PWM/Inc/PWM.h
+++ b/dsx-fw/DSX_Library/PWM/Inc/PWM.h
@@ -12,8 +12,8 @@
 /* Macros that store the min and max values for the
  * frequency and duty cycle
  */
-#define PWM_Max 		1700000U
-#define PWM_Min 		34U
+#define PWM_Max 		1700000U         // Max available after dividing the clock clock by the period
+#define PWM_Min 		26U              // Min as prescaler can be up to 65535. PWM_Min = PWM_Max/65384
 #define dutyCycle_Max 	100U
 #define dutyCycle_Min 	0
 #define CLOCK_SPEED		170000000UL

--- a/dsx-fw/DSX_Library/PWM/Src/PWM.c
+++ b/dsx-fw/DSX_Library/PWM/Src/PWM.c
@@ -10,6 +10,7 @@ extern TIM_HandleTypeDef htim17;
 // Function for updating the PWM duty cycle
 void updateDutyCycle (TIM_HandleTypeDef htim, uint8_t dutyCycle)
 {
+	// Remove after writing checks in the execution of commands
 	if (dutyCycle > dutyCycle_Max){
 		dutyCycle = dutyCycle_Max;
 	}
@@ -24,6 +25,7 @@ void updateDutyCycle (TIM_HandleTypeDef htim, uint8_t dutyCycle)
 // Function for that updates the PWM frequency
 void updatePWMFrequency (TIM_HandleTypeDef htim, uint32_t pwm_freq)
 {
+	// Remove after writing checks in the execution of commands
 	if (pwm_freq > PWM_Max){
 		pwm_freq = PWM_Max;
 	}


### PR DESCRIPTION
- Based off the calculations, the maximum prescaler we can set is 65384 to get a minimum PWM frequency of 26 Hz.
- Added comments to remember to remove the internal checks for invalid frequency and duty cycle values in the PWM source file
- I don't know why the language settings are different??? I never changed them lol